### PR TITLE
Corrigido nome da cidade de Tufilândia-MA

### DIFF
--- a/20090212172415_popula_estados_cidades.rb
+++ b/20090212172415_popula_estados_cidades.rb
@@ -1403,7 +1403,7 @@ class PopulaEstadosCidades < ActiveRecord::Migration
     e.cidades.create(:nome => "Timbiras")
     e.cidades.create(:nome => "Timon")
     e.cidades.create(:nome => "Trizidela do Vale")
-    e.cidades.create(:nome => "Tsiglailândia")
+    e.cidades.create(:nome => "Tufilândia")
     e.cidades.create(:nome => "Tuntum")
     e.cidades.create(:nome => "Turiaçu")
     e.cidades.create(:nome => "Turilândia")
@@ -5720,7 +5720,7 @@ class PopulaEstadosCidades < ActiveRecord::Migration
     e.cidades.create(:nome => "Xambioá")
     e.capital = Cidade.find_by_nome_and_estado_id('Palmas', Estado.find_by_nome('Tocantins').id)
     e.save
-    
+
   end
 
   def self.down


### PR DESCRIPTION
Foi corrigido o nome da cidade de Tufilândia-MA. 
Antes estava como Tsiglailândia. 
Parece problema no script que gera o arquivo, acredito que por ter um 'uf' no meio do nome da cidade.
