### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Migration que popula o banco de dados com os estados e cidades do Brasil com dad
 
 Para utilizá-la é necessário criar os seguintes models:
 
-##Rails 3##
+## Rails 3 ##
 
 `Estado.rb`
 ```
@@ -23,7 +23,7 @@ class Cidade < ActiveRecord::Base
 end
 ```
 
-##Rails 4##
+## Rails 4 ##
 
 `Estado.rb`
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
